### PR TITLE
CI: build/push staging site image from branches

### DIFF
--- a/.github/workflows/site-staging.yml
+++ b/.github/workflows/site-staging.yml
@@ -1,0 +1,87 @@
+name: Publish website (staging)
+
+on:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - '.github/**'
+      - 'site/**'
+      - 'docs/**'
+      - 'lib/**'
+  workflow_dispatch: {}
+
+concurrency:
+  group: staging-site-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: |
+          pnpm --version || true
+          pnpm install
+
+      - name: Build libraries + typecheck
+        run: pnpm nx run-many -t build,tsc
+
+      - name: Generate docs site
+        run: pnpm run docs
+
+      # Build a static container that serves /site
+      - name: Create Dockerfile (static)
+        working-directory: site
+        run: |
+          cat > Dockerfile <<'EOF'
+          FROM ghcr.io/cloud-cli/static
+          COPY --chown=node:node . /home/app/dist
+          LABEL org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+          EOF
+          cat Dockerfile
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=branch,prefix=staging-
+            type=sha,format=short
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push (staging)
+        uses: docker/build-push-action@v6
+        with:
+          context: site
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds a second GitHub Actions workflow that builds and pushes a *staging* Docker image for the website on every branch push (excluding main).\n\n- Trigger: push to non-main branches (paths: site/docs/lib/.github) + manual workflow_dispatch\n- Builds libs + typecheck, generates docs into site/docs, then builds a static image from /site\n- Publishes to GHCR with tags: `staging-<branch>` and `sha-<short>` (via docker/metadata-action)\n\nThis lets us test landing-page and docs changes without affecting the main site image.